### PR TITLE
Support <script> tag for markup templates

### DIFF
--- a/Syntaxes/HTML (Twig).tmLanguage
+++ b/Syntaxes/HTML (Twig).tmLanguage
@@ -282,7 +282,7 @@
                 </dict>
             </dict>
             <key>end</key>
-            <string>(?&lt;=&lt;/(script|SCRIPT))(&gt;)(?:\s*\n)?</string>
+            <string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*type=["']text\/(?:html|template)['"]|[^&gt;]*\/&gt;)</string>
             <key>endCaptures</key>
             <dict>
                 <key>2</key>


### PR DESCRIPTION
Syntax was breaking when incurring into

`<script type="text/html">` and `<script type="text/template">`, that are used for defining markup templates.

The regular expression has been fixed to not consider the content of these tags as Javascript content, but to keep highlighting as HTML markup.